### PR TITLE
Add Firebase Hosting deploy (cdn.mapgallery.online)

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "mapgallery-216911"
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Required secret:
+#   FIREBASE_SERVICE_ACCOUNT_MAPGALLERY_216911 - JSON service account key with Firebase Hosting Admin
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MAPGALLERY_216911 }}
+      - run: npm install -g firebase-tools
+
+      - name: Deploy live (master)
+        if: github.event_name == 'push'
+        run: firebase deploy --only hosting --project mapgallery-216911 --non-interactive
+
+      - name: Deploy preview channel (PR)
+        if: github.event_name == 'pull_request'
+        id: preview
+        run: |
+          OUTPUT=$(firebase hosting:channel:deploy pr-${{ github.event.pull_request.number }} \
+            --expires 7d \
+            --project mapgallery-216911 \
+            --non-interactive \
+            --json)
+          URL=$(echo "$OUTPUT" | jq -r '[.result[]][0].url')
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request' && steps.preview.outputs.url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "Preview deployed: ${{ steps.preview.outputs.url }} (expires in 7 days)"

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,34 @@
+{
+  "hosting": {
+    "site": "mapgallery-cdn",
+    "public": ".",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**",
+      "package.json",
+      "package-lock.json",
+      "README.md",
+      "LICENSE"
+    ],
+    "headers": [
+      {
+        "source": "**/*.@(js|css|svg|png|jpg|jpeg|webp|woff|woff2)",
+        "headers": [
+          {
+            "key": "Access-Control-Allow-Origin",
+            "value": "*"
+          },
+          {
+            "key": "Cross-Origin-Resource-Policy",
+            "value": "cross-origin"
+          },
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=3600"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -9,7 +9,9 @@
       "package.json",
       "package-lock.json",
       "README.md",
-      "LICENSE"
+      "LICENSE",
+      "index.html",
+      "images/**"
     ],
     "headers": [
       {


### PR DESCRIPTION
## Summary
Sets up this repo to deploy to a dedicated Firebase Hosting site so the MapGallery scripts have a single source of truth — instead of being copy-pasted into both `map-gallery-editor` and `map-gallery-firebase` under their respective `public/MapGallery/` folders.

## What's added
- **`firebase.json`** — hosting config targeting site `mapgallery-cdn` with:
  - `Access-Control-Allow-Origin: *` + `Cross-Origin-Resource-Policy: cross-origin` on JS/CSS/image assets so they load cleanly from any domain
  - `Cache-Control: public, max-age=3600` (1h browser cache; can crank up once URLs are content-hashed)
  - Excludes `package.json`, `README.md`, `LICENSE` from the deploy
- **`.firebaserc`** — project `mapgallery-216911`
- **`.github/workflows/deploy.yml`** — same auth-then-CLI pattern as the editor repo:
  - on master push: `firebase deploy --only hosting` (live channel)
  - on PR: `firebase hosting:channel:deploy pr-<num>` + auto PR comment with preview URL
- **`.github/dependabot.yml`** — monthly npm + github-actions updates

## Before merging — manual setup
1. **Firebase Console** → Hosting → **Create new site** in project `mapgallery-216911` named `mapgallery-cdn`
2. (Optional) Add custom domain `cdn.mapgallery.online` to that site (DNS + verification, same as `editor.mapgallery.online`)
3. **GitHub Settings → Secrets** → Add `FIREBASE_SERVICE_ACCOUNT_MAPGALLERY_216911` (same JSON service account used by the other two repos)

## After merging
Follow-up PRs in `map-gallery-editor` and `map-gallery-firebase` to point their `<script src=...>` references at the CDN and delete the duplicated `public/MapGallery/` folders.

## Test plan
- [ ] PR preview deploys, scripts load with CORS headers from a cross-origin page
- [ ] After merge: live site at `mapgallery-cdn.web.app` serves all assets
- [ ] After DNS: `cdn.mapgallery.online/scripts/MapAnimator.js` returns 200 with the expected headers